### PR TITLE
chore: ignore .gem builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+
+*.gem


### PR DESCRIPTION
Ignores .gem files that are built when building the gem locally.